### PR TITLE
Issue #11: Expand legacy index router aliases

### DIFF
--- a/ddcz/tests/test_integration/test_legacy_redirects.py
+++ b/ddcz/tests/test_integration/test_legacy_redirects.py
@@ -3,6 +3,8 @@ from django.test import Client, TestCase
 from ddcz.models import (
     ApprovalChoices,
     CommonArticle,
+    DownloadItem,
+    Photo,
     RangerSpell,
     Skill,
     UserProfile,
@@ -81,6 +83,87 @@ class TestUserProfileRedirect(TestCase):
         )
         self.assertEquals(response.status_code, 301)
         self.assertEquals(response.url, f"/uzivatel/{self.user.id}-test/")
+
+
+class TestLegacyIndexRouter(TestCase):
+    fixtures = ["pages"]
+
+    def setUp(self):
+        super().setUp()
+        self.client = Client()
+
+    def test_downloads_list_redirect(self):
+        response = self.client.get("/index.php?rub=downloady")
+        self.assertEquals(response.status_code, 302)
+        self.assertEquals(response.url, "/rubriky/downloady/")
+
+    def test_links_discussion_redirect(self):
+        response = self.client.get("/index.php?rub=linky_diskuze")
+        self.assertEquals(response.status_code, 302)
+        self.assertEquals(response.url, "/linky/")
+
+    def test_creative_page_read_alias_redirect(self):
+        skill = Skill.objects.create(id=42, name="Test skill", description="yolo")
+
+        response = self.client.get(f"/index.php?rub=dovednosti_precti&id={skill.id}")
+
+        self.assertEquals(response.status_code, 301)
+        self.assertEquals(
+            response.url,
+            f"/rubriky/dovednosti/{skill.id}-{skill.get_slug()}/",
+        )
+
+    def test_common_article_discussion_redirect(self):
+        article = CommonArticle.objects.create(
+            id=128,
+            name="Test article",
+            creative_page_slug="clanky",
+            is_published=CommonArticle.CREATION_APPROVED,
+        )
+
+        response = self.client.get(
+            f"/index.php?rub=prispevky_diskuze&co=clanky&id={article.id}"
+        )
+
+        self.assertEquals(response.status_code, 301)
+        self.assertEquals(
+            response.url,
+            f"/rubriky/clanky/{article.id}-{article.get_slug()}/",
+        )
+
+    def test_download_discussion_alias_redirect(self):
+        download = DownloadItem.objects.create(
+            id=8,
+            name="Test download",
+            format="pdf",
+            description="yolo",
+            size=123,
+            group="test",
+        )
+
+        response = self.client.get(f"/index.php?rub=downloady_diskuze&id={download.id}")
+
+        self.assertEquals(response.status_code, 301)
+        self.assertEquals(
+            response.url,
+            f"/rubriky/downloady/{download.id}-{download.get_slug()}/",
+        )
+
+    def test_gallery_discussion_alias_redirect(self):
+        photo = Photo.objects.create(
+            id=13,
+            name="Test photo",
+            image_path="photo.jpg",
+            image_thumbnail_path="thumb.jpg",
+        )
+
+        response = self.client.get(f"/index.php?rub=fotogalerie_diskuze&id={photo.id}")
+
+        self.assertEquals(response.status_code, 301)
+        self.assertEquals(
+            response.url,
+            f"/rubriky/fotogalerie/{photo.id}-{photo.get_slug()}/",
+        )
 
 
 class TestCommonArticlePrintRedirect(TestCase):

--- a/ddcz/views/legacy.py
+++ b/ddcz/views/legacy.py
@@ -21,11 +21,11 @@ logger = logging.getLogger(__name__)
 # remains automatized.
 
 CREATION_LIST = ["prispevky", "prispevky_komp"]
-CREATION_DETAIL = "prispevky_precti"
+COMMON_ARTICLE_DETAIL = ["prispevky_precti", "prispevky_diskuze"]
 USER_DETAIL = ["uzivatele_podrobnosti", "runy_ciziod", "runy_cizipro"]
 
 # Forbidden dictionary keys for PAGE_TO_VIEW_MAP:
-#  - Anything from CREATION and CREATION_DETAIL
+#  - Anything from CREATION_LIST and COMMON_ARTICLE_DETAIL
 #  - Anything from ALLOWED_CREATION_PAGES
 PAGE_TO_VIEW_MAP = {
     "aktuality": "ddcz:news",
@@ -35,6 +35,7 @@ PAGE_TO_VIEW_MAP = {
     "seznamka": "ddcz:dating",
     "forum": "ddcz:phorum-list",
     "linky": "ddcz:links-list",
+    "linky_diskuze": "ddcz:links-list",
     "inzerce": "ddcz:market",
     "credits": "ddcz:web-authors-and-editors",
     "faq": "ddcz:website-manual",
@@ -72,7 +73,23 @@ ALLOWED_CREATION_PAGES = [
     "dovednosti",
     "galerie",
     "fotogalerie",
+    "downloady",
 ]
+
+
+CREATION_DETAIL_BY_LEGACY_PAGE = {
+    f"{name}_jeden": name for name in ALLOWED_CREATION_PAGES
+}
+CREATION_DETAIL_BY_LEGACY_PAGE.update(
+    {
+        "dobrodruzstvi_precti": "dobrodruzstvi",
+        "dobrodruzstvi_diskuze": "dobrodruzstvi",
+        "dovednosti_precti": "dovednosti",
+        "galerie_diskuze": "galerie",
+        "fotogalerie_diskuze": "fotogalerie",
+        "downloady_diskuze": "downloady",
+    }
+)
 
 
 @require_http_methods(["HEAD", "GET"])
@@ -111,9 +128,9 @@ def legacy_router(request):
             )
         )
 
-    # For index.php?rub=prispevky_jeden&subsection=page_slug&id=article_id
+    # For index.php?rub=prispevky_precti&co=page_slug&id=article_id
     # we can find the article detail by Id.
-    if page_category == CREATION_DETAIL and id is not False:
+    if page_category in COMMON_ARTICLE_DETAIL and id is not False:
         page = get_object_or_404(CreativePage, slug=page_creation_type)
         return get_creation_detail_redirect(page, id)
 
@@ -133,7 +150,7 @@ def legacy_router(request):
 
     # There are some special creative pages that are not stored
     # as the others, those have their own tables in the database.
-    # For those we have lists and details in this for loop.
+    # For those we have list redirects in this loop and detail aliases below.
     for name in ALLOWED_CREATION_PAGES:
         if page_category in [name, name + "_komp"]:
             return HttpResponseRedirect(
@@ -142,9 +159,11 @@ def legacy_router(request):
                     kwargs={"creative_page_slug": name},
                 )
             )
-        if page_category in [name + "_jeden"]:
-            page = get_object_or_404(CreativePage, slug=name)
-            return get_creation_detail_redirect(page, id)
+    if page_category in CREATION_DETAIL_BY_LEGACY_PAGE:
+        page = get_object_or_404(
+            CreativePage, slug=CREATION_DETAIL_BY_LEGACY_PAGE[page_category]
+        )
+        return get_creation_detail_redirect(page, id)
 
     # Putyka table redirects (we have a referral from DrD2 official site, actually)
     if page_category == "putyka_jeden":
@@ -153,12 +172,6 @@ def legacy_router(request):
                 "ddcz:tavern-posts",
                 kwargs={"tavern_table_id": id},
             )
-        )
-
-    # Galerie is also somewhat often referenced
-    if page_category == "galerie_diskuze":
-        return get_creation_detail_redirect(
-            CreativePage.objects.get(slug="galerie"), id
         )
 
     ###  Finally if no route is found, redirect to news and log


### PR DESCRIPTION
## Summary
- map additional old `index.php?rub=...` aliases from upstream issue #11 to their modern routes
- add `downloady` to legacy creative-page list/detail routing
- add integration coverage for download, links, common article, skill, and photo legacy aliases

## Validation
- `docker run --rm --network dracidoupecz-graveyard_default -v "$PWD":/code -w /code -e SERVER_CI=true graveyard-web-test python3 manage.py test ddcz.tests.test_integration.test_legacy_redirects` (15 tests passed)
- `python -m py_compile ddcz/views/legacy.py ddcz/tests/test_integration/test_legacy_redirects.py`
- `git diff --check`

Upstream issue: dracidoupe/graveyard#11

Note: this PR targets the fork only (`jimmeak/graveyard:master`) and does not open a PR against upstream.